### PR TITLE
fix rendering of search box for firefox

### DIFF
--- a/templateToc.html
+++ b/templateToc.html
@@ -44,7 +44,7 @@
       <h1 id="title" class="pull-left">openFrameworks documentation</h1>
       <div class="pull-right labelToggle"><a onclick="$('.label').toggle()" href="#">Toggle completion</a></div>
       <div class="form-group">
-        <input type="text"  id="search" class="form-control" placeholder="What are you looking for?" autocomplete="off">
+        <input type="text"  id="search pull-left" class="form-control" placeholder="What are you looking for?" autocomplete="off">
       </div>
       <ul class="searchResult hidden searchResultNavbar"></ul>
     </div>


### PR DESCRIPTION
this pulls the search box left, so it doesn't scroll off screen

![screen shot 2015-04-04 at 13 22 27](https://cloud.githubusercontent.com/assets/32407/6993771/b7d59544-dacd-11e4-8111-cf73e6e57589.png)
![screen shot 2015-04-04 at 13 22 45](https://cloud.githubusercontent.com/assets/32407/6993772/b7d8d57e-dacd-11e4-9a2b-1c6d4bf77a77.png)
