### PR TITLE
Make start script bail when commands fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "doxygen": "doxygen Doxyfile",
     "parse": "node app.js",
     "sass": "sass assets/stylesheet.scss output/stylesheet.css",
-    "start": "npm run doxygen; npm run parse; npm run sass"
+    "start": "npm run doxygen && npm run parse && npm run sass"
   },
   "dependencies": {
     "cheerio": "^0.18.0",


### PR DESCRIPTION
This way, the docs step [really fails](https://travis-ci.org/openframeworks/openFrameworks/jobs/72270319) when it encounters a problem during npm run start.
